### PR TITLE
[WHAL-76] React 자동배포 (#64)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to EC2
+on:
+  push:
+    branches:
+      - master
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@master
+
+    - name: create env file
+      run: |
+        touch .env
+        echo "${{ secrets.ENV_VARS }}" >> .env
+
+    - name: create remote directory
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ubuntu
+        key: ${{ secrets.KEY }}
+        script: mkdir -p /home/ubuntu/srv/ubuntu/frontend
+
+    - name: copy source via ssh key
+      uses: burnett01/rsync-deployments@4.1
+      with:
+        switches: -avzr --delete
+        remote_path: /home/ubuntu/srv/ubuntu/frontend
+        remote_host: ${{ secrets.HOST }}
+        remote_user: ubuntu
+        remote_key: ${{ secrets.KEY }}
+
+    - name: executing remote ssh commands using password
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ubuntu
+        key: ${{ secrets.KEY }}
+        script: |
+          sh /home/ubuntu/srv/ubuntu/config/scripts/deploy.sh
+          
+    - name: delete useless images and containers
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ubuntu
+        key: ${{ secrets.KEY }}
+        script: |
+          sudo yes y | sudo docker image prune
+          sudo yes y | sudo docker container prune

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:alpine as builder
+
+WORKDIR '/app'
+# add `/app/node_modules/.bin` to $PATH
+ENV PATH /app/node_modules/.bin:$PATH
+# 필수 패키지 파일을 이미지 내부로 복사하고, npm 명령어로 설치합니다
+RUN npm config set unsafe-perm true
+COPY ./package*.json ./
+RUN mkdir -p /app/node_modules
+RUN chown node:node /app/node_modules
+
+RUN npm install --force
+COPY ./ ./
+RUN chmod -R 777 /app
+USER node
+#RUN yarn build
+#COPY --from=builder /app/build ./
+#CMD ["yarn", "start"]


### PR DESCRIPTION
* Create deploy.sh

* Update deploy.sh

* Create Dockerfile

* Update Dockerfile

* Create docker-compose.prod.yml

* Create deploy.yml

* Update docker-compose.prod.yml

* Update deploy.yml

* Update Dockerfile

* Update docker-compose.prod.yml

* Update Dockerfile

* Update Dockerfile

* Update deploy.yml

* Update docker-compose.prod.yml

* Update Dockerfile

* Update Dockerfile

* Update Dockerfile

* Update deploy.yml

* Update Dockerfile

* Create entrypoint.sh

* Update Dockerfile

* Rename entrypoint.sh to entrypoint.react.sh

* Update Dockerfile

* Delete entrypoint.react.sh

* Create entrypoint.react.sh

* Delete entrypoint.react.sh

* Update Dockerfile

* Update Dockerfile

* Update Dockerfile

* Update Dockerfile

* Delete docker-compose.prod.yml

* Master에서만 Deploy하도록 수정

* Delete config/scipts Directory -> 쓸 일 없음